### PR TITLE
Rework Power

### DIFF
--- a/StarRailBattleSim/src/battleLogic/Battle.java
+++ b/StarRailBattleSim/src/battleLogic/Battle.java
@@ -5,6 +5,7 @@ import characters.SwordMarch;
 import characters.Yunli;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
+import powers.PowerStat;
 import relics.AbstractRelicSetBonus;
 
 import java.util.ArrayList;
@@ -172,7 +173,7 @@ public class Battle {
                 }
             }
             for (AbstractPower power : powersToRemove) {
-                if (power.bonusSpeedPercent > 0 || power.bonusFlatSpeed > 0) {
+                if (power.getStat(PowerStat.SPEED_PERCENT) > 0 || power.getStat(PowerStat.FLAT_SPEED) > 0) {
                     DecreaseSpeed(nextUnit, power);
                 } else {
                     nextUnit.removePower(power);

--- a/StarRailBattleSim/src/battleLogic/BattleHelpers.java
+++ b/StarRailBattleSim/src/battleLogic/BattleHelpers.java
@@ -5,6 +5,7 @@ import characters.Moze;
 import characters.SwordMarch;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
+import powers.PowerStat;
 import relics.AbstractRelicSetBonus;
 
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public class BattleHelpers {
 
         float damageTaken = 0;
         for (AbstractPower power : target.powerList) {
-            damageTaken += power.bonusDamageTaken;
+            damageTaken += power.getStat(PowerStat.DAMAGE_TAKEN);
             damageTaken += power.getConditionalDamageTaken(source, target, types);
         }
         float damageTakenMultiplier = 1 + damageTaken / 100;
@@ -129,7 +130,7 @@ public class BattleHelpers {
         types.add(AbstractCharacter.DamageType.BREAK);
         float damageTaken = 0;
         for (AbstractPower power : target.powerList) {
-            damageTaken += power.bonusDamageTaken;
+            damageTaken += power.getStat(PowerStat.DAMAGE_TAKEN);
             damageTaken += power.getConditionalDamageTaken(source, target, types);
         }
         float damageTakenMultiplier = 1 + damageTaken / 100;

--- a/StarRailBattleSim/src/characters/AbstractCharacter.java
+++ b/StarRailBattleSim/src/characters/AbstractCharacter.java
@@ -4,7 +4,9 @@ import battleLogic.AbstractEntity;
 import battleLogic.Battle;
 import enemies.AbstractEnemy;
 import lightcones.AbstractLightcone;
+import lightcones.DefaultLightcone;
 import powers.AbstractPower;
+import powers.PowerStat;
 import relics.AbstractRelicSetBonus;
 
 import java.util.ArrayList;
@@ -85,6 +87,8 @@ public abstract class AbstractCharacter extends AbstractEntity {
         powerList = new ArrayList<>();
         relicSetBonus = new ArrayList<>();
         moveHistory = new ArrayList<>();
+
+        this.lightcone = new DefaultLightcone(this);
     }
 
     public void useSkill() {
@@ -141,9 +145,9 @@ public abstract class AbstractCharacter extends AbstractEntity {
         float totalBonusAtkPercent = 0;
         int totalBonusFlatAtk = 0;
         for (AbstractPower power : powerList) {
-            totalBonusAtkPercent += power.bonusAtkPercent;
+            totalBonusAtkPercent += power.getStat(PowerStat.ATK_PERCENT);
             totalBonusAtkPercent += power.getConditionalAtkBonus(this);
-            totalBonusFlatAtk += power.bonusFlatAtk;
+            totalBonusFlatAtk += power.getStat(PowerStat.FLAT_ATK);
         }
         return (totalBaseAtk * (1 + totalBonusAtkPercent / 100) + totalBonusFlatAtk);
     }
@@ -153,8 +157,8 @@ public abstract class AbstractCharacter extends AbstractEntity {
         float totalBonusDefPercent = 0;
         int totalBonusFlatDef = 0;
         for (AbstractPower power : powerList) {
-            totalBonusDefPercent += power.bonusDefPercent;
-            totalBonusFlatDef += power.bonusFlatDef;
+            totalBonusDefPercent += power.getStat(PowerStat.DEF_PERCENT);
+            totalBonusFlatDef += power.getStat(PowerStat.FLAT_DEF);
         }
         return (totalBaseDef * (1 + totalBonusDefPercent / 100) + totalBonusFlatDef);
     }
@@ -164,8 +168,8 @@ public abstract class AbstractCharacter extends AbstractEntity {
         float totalBonusHPPercent = 0;
         int totalBonusFlatHP = 0;
         for (AbstractPower power : powerList) {
-            totalBonusHPPercent += power.bonusHPPercent;
-            totalBonusFlatHP += power.bonusFlatHP;
+            totalBonusHPPercent += power.getStat(PowerStat.HP_PERCENT);
+            totalBonusFlatHP += power.getStat(PowerStat.FLAT_HP);
         }
         return (totalBaseHP * (1 + totalBonusHPPercent / 100) + totalBonusFlatHP);
     }
@@ -175,8 +179,8 @@ public abstract class AbstractCharacter extends AbstractEntity {
         float totalBonusSpeedPercent = 0;
         float totalBonusFlatSpeed = 0;
         for (AbstractPower power : powerList) {
-            totalBonusSpeedPercent += power.bonusSpeedPercent;
-            totalBonusFlatSpeed += power.bonusFlatSpeed;
+            totalBonusSpeedPercent += power.getStat(PowerStat.SPEED_PERCENT);
+            totalBonusFlatSpeed += power.getStat(PowerStat.FLAT_SPEED);
         }
         return (totalBaseSpeed * (1 + totalBonusSpeedPercent / 100) + totalBonusFlatSpeed);
     }
@@ -184,7 +188,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalCritChance() {
         float totalCritChance = baseCritChance;
         for (AbstractPower power : powerList) {
-            totalCritChance += power.bonusCritChance;
+            totalCritChance += power.getStat(PowerStat.CRIT_CHANCE);
         }
         if (totalCritChance > 100) {
             totalCritChance = 100;
@@ -195,7 +199,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalCritDamage() {
         float totalCritDamage = baseCritDamage;
         for (AbstractPower power : powerList) {
-            totalCritDamage += power.bonusCritDamage;
+            totalCritDamage += power.getStat(PowerStat.CRIT_DAMAGE);
         }
         return totalCritDamage;
     }
@@ -204,8 +208,8 @@ public abstract class AbstractCharacter extends AbstractEntity {
         float totalSameElementDamageBonus = 0;
         float totalGlobalElementDamageBonus = 0;
         for (AbstractPower power : powerList) {
-            totalSameElementDamageBonus += power.bonusSameElementDamageBonus;
-            totalGlobalElementDamageBonus += power.bonusDamageBonus;
+            totalSameElementDamageBonus += power.getStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS);
+            totalGlobalElementDamageBonus += power.getStat(PowerStat.DAMAGE_BONUS);
         }
         return totalSameElementDamageBonus + totalGlobalElementDamageBonus;
     }
@@ -213,7 +217,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalOffElementDamageBonus() {
         float totalGlobalElementDamageBonus = 0;
         for (AbstractPower power : powerList) {
-            totalGlobalElementDamageBonus += power.bonusDamageBonus;
+            totalGlobalElementDamageBonus += power.getStat(PowerStat.DAMAGE_BONUS);
         }
         return totalGlobalElementDamageBonus;
     }
@@ -221,7 +225,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalResPen() {
         int totalResPen = 0;
         for (AbstractPower power : powerList) {
-            totalResPen += power.resPen;
+            totalResPen += power.getStat(PowerStat.RES_PEN);
         }
         return totalResPen;
     }
@@ -230,7 +234,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
         int baseTauntValue = tauntValue;
         float totalBonusTauntValue = 0;
         for (AbstractPower power : powerList) {
-            totalBonusTauntValue += power.bonusTauntValue;
+            totalBonusTauntValue += power.getStat(PowerStat.TAUNT_VALUE);
         }
         return (baseTauntValue * (1 + totalBonusTauntValue / 100));
     }
@@ -238,7 +242,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalERR() {
         float totalEnergyRegenBonus = 0;
         for (AbstractPower power : powerList) {
-            totalEnergyRegenBonus += power.bonusEnergyRegen;
+            totalEnergyRegenBonus += power.getStat(PowerStat.ENERGY_REGEN);
             totalEnergyRegenBonus += power.getConditionalERR(this);
         }
         return totalEnergyRegenBonus;
@@ -247,7 +251,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalEHR() {
         float totalEHR = 0;
         for (AbstractPower power : powerList) {
-            totalEHR += power.bonusEffectHit;
+            totalEHR += power.getStat(PowerStat.EFFECT_HIT);
         }
         return totalEHR;
     }
@@ -255,7 +259,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalEffectRes() {
         float totalEffectRes = 0;
         for (AbstractPower power : powerList) {
-            totalEffectRes += power.bonusEffectRes;
+            totalEffectRes += power.getStat(PowerStat.EFFECT_RES);
         }
         return totalEffectRes;
     }
@@ -263,7 +267,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalBreakEffect() {
         float totalBreakEffect = 0;
         for (AbstractPower power : powerList) {
-            totalBreakEffect += power.bonusBreakEffect;
+            totalBreakEffect += power.getStat(PowerStat.BREAK_EFFECT);
         }
         return totalBreakEffect;
     }
@@ -271,7 +275,7 @@ public abstract class AbstractCharacter extends AbstractEntity {
     public float getTotalWeaknessBreakEff() {
         float totalWeaknessBreakEff = 0;
         for (AbstractPower power : powerList) {
-            totalWeaknessBreakEff += power.bonusWeaknessBreakEff;
+            totalWeaknessBreakEff += power.getStat(PowerStat.WEAKNESS_BREAK_EFF);
         }
         return totalWeaknessBreakEff;
     }

--- a/StarRailBattleSim/src/characters/Asta.java
+++ b/StarRailBattleSim/src/characters/Asta.java
@@ -23,9 +23,9 @@ public class Asta extends AbstractCharacter {
         super(NAME, 1023, 512, 463, 106, 80, ElementType.FIRE, 120, 100, Path.HARMONY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
-                .addStat(PowerStat.DEF_PERCENT, 22.5f)
-                .addStat(PowerStat.CRIT_CHANCE, 6.7f));
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .setStat(PowerStat.DEF_PERCENT, 22.5f)
+                .setStat(PowerStat.CRIT_CHANCE, 6.7f));
 
         talentPower = new AstaTalentPower();
         skillEnergyGain = 36;

--- a/StarRailBattleSim/src/characters/Asta.java
+++ b/StarRailBattleSim/src/characters/Asta.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -20,12 +22,10 @@ public class Asta extends AbstractCharacter {
     public Asta() {
         super(NAME, 1023, 512, 463, 106, 80, ElementType.FIRE, 120, 100, Path.HARMONY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusSameElementDamageBonus = 22.4f;
-        tracesPower.bonusDefPercent = 22.5f;
-        tracesPower.bonusCritChance = 6.7f;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .addStat(PowerStat.DEF_PERCENT, 22.5f)
+                .addStat(PowerStat.CRIT_CHANCE, 6.7f));
 
         talentPower = new AstaTalentPower();
         skillEnergyGain = 36;
@@ -75,11 +75,7 @@ public class Asta extends AbstractCharacter {
     public void useUltimate() {
         super.useUltimate();
         for (AbstractCharacter character : Battle.battle.playerTeam) {
-            TempPower ultBuff = new TempPower();
-            ultBuff.bonusFlatSpeed = 53;
-            ultBuff.turnDuration = 2;
-            ultBuff.name = "Asta Ult Speed Buff";
-            Battle.battle.IncreaseSpeed(character, ultBuff);
+            Battle.battle.IncreaseSpeed(character, TempPower.create(PowerStat.FLAT_SPEED, 53, 2, "Asta Ult Speed Buff"));
         }
         justCastUlt = true;
     }
@@ -97,10 +93,7 @@ public class Asta extends AbstractCharacter {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             character.addPower(talentPower);
             if (character.elementType == ElementType.FIRE) {
-                PermPower firePower = new PermPower();
-                firePower.bonusSameElementDamageBonus = 18;
-                firePower.name = "Asta Fire Damage Bonus";
-                character.addPower(firePower);
+                character.addPower(PermPower.create(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 18, "Asta Fire Damage Bonus"));
             }
         }
         addPower(new AstaERRPower());

--- a/StarRailBattleSim/src/characters/Aventurine.java
+++ b/StarRailBattleSim/src/characters/Aventurine.java
@@ -6,7 +6,6 @@ import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
 import powers.PowerStat;
-import powers.TempPower;
 import powers.TracePower;
 
 import java.util.ArrayList;
@@ -32,9 +31,9 @@ public class Aventurine extends AbstractCharacter {
 
         this.SPNeutral = SPNeutral;
         this.addPower(new TracePower()
-                .addStat(PowerStat.DEF_PERCENT, 35)
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 14.4f)
-                .addStat(PowerStat.EFFECT_RES, 10));
+                .setStat(PowerStat.DEF_PERCENT, 35)
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 14.4f)
+                .setStat(PowerStat.EFFECT_RES, 10));
         this.hasAttackingUltimate = true;
     }
 

--- a/StarRailBattleSim/src/characters/Aventurine.java
+++ b/StarRailBattleSim/src/characters/Aventurine.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,12 +31,10 @@ public class Aventurine extends AbstractCharacter {
         super("Aventurine", 1203, 446, 655, 106, 80, ElementType.IMAGINARY, 110, 150, Path.PRESERVATION);
 
         this.SPNeutral = SPNeutral;
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusDefPercent = 35;
-        tracesPower.bonusSameElementDamageBonus = 14.4f;
-        tracesPower.bonusEffectRes = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.DEF_PERCENT, 35)
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 14.4f)
+                .addStat(PowerStat.EFFECT_RES, 10));
         this.hasAttackingUltimate = true;
     }
 
@@ -121,10 +121,7 @@ public class Aventurine extends AbstractCharacter {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             character.addPower(talentPower);
         }
-        PermPower defenseCritPower = new PermPower();
-        defenseCritPower.bonusCritChance = 48;
-        defenseCritPower.name = "Aventurine Crit Chance Bonus";
-        addPower(defenseCritPower);
+        addPower(PermPower.create(PowerStat.CRIT_CHANCE, 48, "Aventurine Crit Chance Bonus"));
     }
 
     public void onTurnStart() {

--- a/StarRailBattleSim/src/characters/Bronya.java
+++ b/StarRailBattleSim/src/characters/Bronya.java
@@ -21,9 +21,9 @@ public class Bronya extends AbstractCharacter {
         super(NAME, 1242, 582, 534, 99, 80, ElementType.WIND, 120, 100, Path.HARMONY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
-                .addStat(PowerStat.CRIT_DAMAGE, 24)
-                .addStat(PowerStat.EFFECT_RES, 10));
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .setStat(PowerStat.CRIT_DAMAGE, 24)
+                .setStat(PowerStat.EFFECT_RES, 10));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Bronya.java
+++ b/StarRailBattleSim/src/characters/Bronya.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -18,20 +20,15 @@ public class Bronya extends AbstractCharacter {
     public Bronya() {
         super(NAME, 1242, 582, 534, 99, 80, ElementType.WIND, 120, 100, Path.HARMONY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusCritDamage = 24;
-        tracesPower.bonusSameElementDamageBonus = 22.4f;
-        tracesPower.bonusEffectRes = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .addStat(PowerStat.CRIT_DAMAGE, 24)
+                .addStat(PowerStat.EFFECT_RES, 10));
     }
 
     public void useSkill() {
         super.useSkill();
-        AbstractPower skillPower = new TempPower();
-        skillPower.name = SKILL_POWER_NAME;
-        skillPower.bonusDamageBonus = 66;
-        skillPower.turnDuration = 1;
+        AbstractPower skillPower = TempPower.create(PowerStat.DAMAGE_BONUS, 66, 1, SKILL_POWER_NAME);
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             if (character.isDPS) {
                 character.addPower(skillPower);
@@ -64,8 +61,8 @@ public class Bronya extends AbstractCharacter {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             AbstractPower ultPower = new TempPower();
             ultPower.name = ULT_POWER_NAME;
-            ultPower.bonusAtkPercent = 55;
-            ultPower.bonusCritDamage = 20 + (this.getTotalCritDamage() * 0.16f);
+            ultPower.setStat(PowerStat.ATK_PERCENT, 55);
+            ultPower.setStat(PowerStat.CRIT_DAMAGE, 20 + (this.getTotalCritDamage() * 0.16f));
             ultPower.turnDuration = 2;
             character.removePower(ultPower.name); // remove the old power in case bronya's crit damage changed so we get new snapshot of her buff
             character.addPower(ultPower);
@@ -83,21 +80,14 @@ public class Bronya extends AbstractCharacter {
 
     public void onCombatStart() {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
-            PermPower tracePower = new PermPower();
-            tracePower.bonusDamageBonus = 10;
-            tracePower.name = "Bronya Trace Damage Bonus";
-            character.addPower(tracePower);
+            character.addPower(PermPower.create(PowerStat.DAMAGE_BONUS, 10, "Bronya Trace Damage Bonus"));
         }
-        addPower(new BronyaBasicCritPower());
+        this.addPower(new BronyaBasicCritPower());
     }
 
     public void useTechnique() {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
-            AbstractPower techniquePower = new TempPower();
-            techniquePower.name = "Bronya Technique Power";
-            techniquePower.bonusAtkPercent = 15;
-            techniquePower.turnDuration = 2;
-            character.addPower(techniquePower);
+            character.addPower(TempPower.create(PowerStat.ATK_PERCENT, 15, 2, "Bronya Technique Power"));
         }
     }
 

--- a/StarRailBattleSim/src/characters/Feixiao.java
+++ b/StarRailBattleSim/src/characters/Feixiao.java
@@ -5,14 +5,16 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class Feixiao extends AbstractCharacter {
 
-    PermPower ultBreakEffBuff;
+    PermPower ultBreakEffBuff = PermPower.create(PowerStat.WEAKNESS_BREAK_EFF, 100, "Fei Ult Break Eff Buff");
     private int numFUAs = 0;
     private int numStacks;
     private int wastedStacks;
@@ -30,18 +32,13 @@ public class Feixiao extends AbstractCharacter {
         this.usesEnergy = false;
         this.currentEnergy = 0;
         this.ultCost = 6;
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28f;
-        tracesPower.bonusCritChance = 12f;
-        tracesPower.bonusDefPercent = 12.5f;
-        this.addPower(tracesPower);
         this.isDPS = true;
         this.hasAttackingUltimate = true;
 
-        ultBreakEffBuff = new PermPower();
-        ultBreakEffBuff.bonusWeaknessBreakEff = 100;
-        ultBreakEffBuff.name = "Fei Ult Break Eff Buff";
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.CRIT_CHANCE, 12)
+                .addStat(PowerStat.DEF_PERCENT, 12.5f));
     }
 
 
@@ -73,11 +70,7 @@ public class Feixiao extends AbstractCharacter {
         types.add(DamageType.SKILL);
         BattleHelpers.PreAttackLogic(this, types);
 
-        TempPower atkBonus = new TempPower();
-        atkBonus.bonusAtkPercent = 48;
-        atkBonus.turnDuration = 3;
-        atkBonus.name = "Fei Atk Bonus";
-        addPower(atkBonus);
+        this.addPower(TempPower.create(PowerStat.ATK_PERCENT, 48, 3,"Fei Atk Bonus"));
 
         AbstractEnemy enemy;
         if (Battle.battle.enemyTeam.size() >= 3) {
@@ -123,11 +116,7 @@ public class Feixiao extends AbstractCharacter {
         numFUAs++;
         Battle.battle.addToLog(name + " used Follow Up");
 
-        TempPower dmgBonus = new TempPower();
-        dmgBonus.bonusDamageBonus = 60;
-        dmgBonus.turnDuration = 2;
-        dmgBonus.name = "Fei Damage Bonus";
-        addPower(dmgBonus);
+        addPower(TempPower.create(PowerStat.DAMAGE_BONUS, 60, 2, "Fei Damage Bonus"));
 
         ArrayList<DamageType> types = new ArrayList<>();
         types.add(DamageType.FOLLOW_UP);

--- a/StarRailBattleSim/src/characters/Feixiao.java
+++ b/StarRailBattleSim/src/characters/Feixiao.java
@@ -36,9 +36,9 @@ public class Feixiao extends AbstractCharacter {
         this.hasAttackingUltimate = true;
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.CRIT_CHANCE, 12)
-                .addStat(PowerStat.DEF_PERCENT, 12.5f));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.CRIT_CHANCE, 12)
+                .setStat(PowerStat.DEF_PERCENT, 12.5f));
     }
 
 

--- a/StarRailBattleSim/src/characters/FuXuan.java
+++ b/StarRailBattleSim/src/characters/FuXuan.java
@@ -5,12 +5,13 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
 
 import java.util.ArrayList;
 
 public class FuXuan extends AbstractCharacter {
-    AbstractPower skillPower = new FuXuanSkillPower();
+    AbstractPower skillPower = PermPower.create(PowerStat.CRIT_CHANCE, 12, "Fu Xuan Skill Power");
     private int skillCounter = 0;
 
     public FuXuan() {
@@ -18,9 +19,9 @@ public class FuXuan extends AbstractCharacter {
 
         PermPower tracesPower = new PermPower();
         tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusHPPercent = 18;
-        tracesPower.bonusCritChance = 18.7f;
-        tracesPower.bonusEffectRes = 10;
+        tracesPower.setStat(PowerStat.HP_PERCENT, 18);
+        tracesPower.setStat(PowerStat.CRIT_CHANCE, 18.7f);
+        tracesPower.setStat(PowerStat.EFFECT_RES, 10);
         this.addPower(tracesPower);
         this.hasAttackingUltimate = true;
     }
@@ -85,17 +86,9 @@ public class FuXuan extends AbstractCharacter {
 
     public void useTechnique() {
         skillCounter = 2;
-        skillPower.bonusFlatHP = 0.06f * FuXuan.this.getFinalHP();
+        skillPower.setStat(PowerStat.FLAT_HP, 0.06f * FuXuan.this.getFinalHP());
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             character.addPower(skillPower);
-        }
-    }
-
-    private class FuXuanSkillPower extends AbstractPower {
-        public FuXuanSkillPower() {
-            this.name = this.getClass().getSimpleName();
-            lastsForever = true;
-            this.bonusCritChance = 12;
         }
     }
 }

--- a/StarRailBattleSim/src/characters/Gallagher.java
+++ b/StarRailBattleSim/src/characters/Gallagher.java
@@ -18,9 +18,9 @@ public class Gallagher extends AbstractCharacter {
         super("Gallagher", 1305, 529, 441, 98, 80, ElementType.FIRE, 110, 100,  Path.ABUNDANCE);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.HP_PERCENT, 18)
-                .addStat(PowerStat.BREAK_EFFECT, 13.3f)
-                .addStat(PowerStat.EFFECT_RES, 28));
+                .setStat(PowerStat.HP_PERCENT, 18)
+                .setStat(PowerStat.BREAK_EFFECT, 13.3f)
+                .setStat(PowerStat.EFFECT_RES, 28));
         this.hasAttackingUltimate = true;
     }
 

--- a/StarRailBattleSim/src/characters/Gallagher.java
+++ b/StarRailBattleSim/src/characters/Gallagher.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -15,12 +17,10 @@ public class Gallagher extends AbstractCharacter {
     public Gallagher() {
         super("Gallagher", 1305, 529, 441, 98, 80, ElementType.FIRE, 110, 100,  Path.ABUNDANCE);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusHPPercent = 18;
-        tracesPower.bonusBreakEffect = 13.3f;
-        tracesPower.bonusEffectRes = 28;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.HP_PERCENT, 18)
+                .addStat(PowerStat.BREAK_EFFECT, 13.3f)
+                .addStat(PowerStat.EFFECT_RES, 28));
         this.hasAttackingUltimate = true;
     }
 
@@ -75,10 +75,9 @@ public class Gallagher extends AbstractCharacter {
 
     public void onCombatStart() {
         increaseEnergy(20);
-        PermPower e6buff = new PermPower();
-        e6buff.bonusBreakEffect = 20;
-        e6buff.bonusWeaknessBreakEff = 20;
-        e6buff.name = "Gallagher E6 Buff";
+        PermPower e6buff = new PermPower("Gallagher E6 Buff");
+        e6buff.setStat(PowerStat.BREAK_EFFECT, 20);
+        e6buff.setStat(PowerStat.WEAKNESS_BREAK_EFF, 20);
         addPower(e6buff);
     }
 

--- a/StarRailBattleSim/src/characters/Hanya.java
+++ b/StarRailBattleSim/src/characters/Hanya.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -17,12 +19,10 @@ public class Hanya extends AbstractCharacter {
     public Hanya() {
         super(NAME, 917, 564, 353, 110, 80, ElementType.PHYSICAL, 140, 100, Path.HARMONY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28;
-        tracesPower.bonusFlatSpeed = 9;
-        tracesPower.bonusHPPercent = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.FLAT_SPEED, 9)
+                .addStat(PowerStat.HP_PERCENT, 10));
     }
 
     public void useSkill() {
@@ -46,11 +46,8 @@ public class Hanya extends AbstractCharacter {
         }
         enemy.addPower(burden);
 
-        TempPower speedPower = new TempPower();
-        speedPower.bonusSpeedPercent = 20;
-        speedPower.turnDuration = 1;
+        TempPower speedPower = TempPower.create(PowerStat.SPEED_PERCENT, 20, 1, "Hanya Skill Speed Power");
         speedPower.justApplied = true;
-        speedPower.name = "Hanya Skill Speed Power";
         Battle.battle.IncreaseSpeed(this, speedPower);
 
         BattleHelpers.PostAttackLogic(this, types);
@@ -81,11 +78,9 @@ public class Hanya extends AbstractCharacter {
                 if (existingPower != null) {
                     Battle.battle.DecreaseSpeed(character, existingPower);
                 }
-                TempPower ultBuff = new TempPower();
-                ultBuff.bonusAtkPercent = 65;
-                ultBuff.bonusFlatSpeed = this.getFinalSpeed() * 0.21f;
-                ultBuff.turnDuration = 3;
-                ultBuff.name = ULT_BUFF_NAME;
+                TempPower ultBuff = new TempPower(3, ULT_BUFF_NAME);
+                ultBuff.setStat(PowerStat.ATK_PERCENT, 65);
+                ultBuff.setStat(PowerStat.FLAT_SPEED, this.getFinalSpeed() * 0.21f);
                 Battle.battle.IncreaseSpeed(character, ultBuff);
                 break;
             }
@@ -113,11 +108,8 @@ public class Hanya extends AbstractCharacter {
 
         public void onBeforeHitEnemy(AbstractCharacter character, AbstractEnemy enemy, ArrayList<AbstractCharacter.DamageType> damageTypes) {
             if (damageTypes.contains(DamageType.BASIC) || damageTypes.contains(DamageType.SKILL) || damageTypes.contains(DamageType.ULTIMATE)) {
-                TempPower talentPower = new TempPower();
-                talentPower.turnDuration = 2;
-                talentPower.bonusDamageBonus = 43;
+                TempPower talentPower = TempPower.create(PowerStat.DAMAGE_BONUS, 43, 2, "Hanya Talent Power");
                 talentPower.justApplied = true;
-                talentPower.name = "Hanya Talent Power";
                 character.addPower(talentPower);
             }
         }
@@ -127,18 +119,18 @@ public class Hanya extends AbstractCharacter {
             if (damageTypes.contains(DamageType.BASIC) || damageTypes.contains(DamageType.SKILL) || damageTypes.contains(DamageType.ULTIMATE)) {
                 hitCount++;
                 Battle.battle.addToLog(String.format("Burden is at %d/%d hits", hitCount, hitsToTrigger));
+
                 if (hitCount >= hitsToTrigger) {
                     triggersLeft--;
                     Battle.battle.generateSkillPoint(character, 1);
                     Hanya.this.increaseEnergy(2);
-                    TempPower tracePower = new TempPower();
-                    tracePower.turnDuration = 1;
+
+                    TempPower tracePower = TempPower.create(PowerStat.ATK_PERCENT, 10, 1, "Hanya Trace Atk Power");
                     if (Battle.battle.nextUnit == character) {
                         tracePower.justApplied = true;
                     }
-                    tracePower.bonusAtkPercent = 10;
-                    tracePower.name = "Hanya Trace Atk Power";
                     character.addPower(tracePower);
+
                     hitCount = 0;
                     if (triggersLeft <= 0) {
                         owner.removePower(this);

--- a/StarRailBattleSim/src/characters/Hanya.java
+++ b/StarRailBattleSim/src/characters/Hanya.java
@@ -4,7 +4,6 @@ import battleLogic.Battle;
 import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TempPower;
 import powers.TracePower;
@@ -20,9 +19,9 @@ public class Hanya extends AbstractCharacter {
         super(NAME, 917, 564, 353, 110, 80, ElementType.PHYSICAL, 140, 100, Path.HARMONY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.FLAT_SPEED, 9)
-                .addStat(PowerStat.HP_PERCENT, 10));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.FLAT_SPEED, 9)
+                .setStat(PowerStat.HP_PERCENT, 10));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Huohuo.java
+++ b/StarRailBattleSim/src/characters/Huohuo.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,12 +21,10 @@ public class Huohuo extends AbstractCharacter {
     public Huohuo() {
         super("Huohuo", 1358, 602, 509, 98, 80, ElementType.WIND, 140, 100, Path.ABUNDANCE);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusHPPercent = 28;
-        tracesPower.bonusFlatSpeed = 5;
-        tracesPower.bonusEffectRes = 18;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.HP_PERCENT, 28)
+                .addStat(PowerStat.FLAT_SPEED, 5)
+                .addStat(PowerStat.EFFECT_RES, 18));
     }
 
     public void useSkill() {
@@ -55,11 +55,7 @@ public class Huohuo extends AbstractCharacter {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             if (character != this) {
                 character.increaseEnergy(character.maxEnergy * 0.2f, false);
-                TempPower tailAtkBonus = new TempPower();
-                tailAtkBonus.bonusAtkPercent = 40;
-                tailAtkBonus.turnDuration = 2;
-                tailAtkBonus.name = "Tail Atk Bonus";
-                character.addPower(tailAtkBonus);
+                character.addPower(TempPower.create(PowerStat.ATK_PERCENT, 40, 2, "Tail Atk Bonus"));
             }
         }
     }

--- a/StarRailBattleSim/src/characters/Huohuo.java
+++ b/StarRailBattleSim/src/characters/Huohuo.java
@@ -4,7 +4,6 @@ import battleLogic.Battle;
 import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TempPower;
 import powers.TracePower;
@@ -22,9 +21,9 @@ public class Huohuo extends AbstractCharacter {
         super("Huohuo", 1358, 602, 509, 98, 80, ElementType.WIND, 140, 100, Path.ABUNDANCE);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.HP_PERCENT, 28)
-                .addStat(PowerStat.FLAT_SPEED, 5)
-                .addStat(PowerStat.EFFECT_RES, 18));
+                .setStat(PowerStat.HP_PERCENT, 28)
+                .setStat(PowerStat.FLAT_SPEED, 5)
+                .setStat(PowerStat.EFFECT_RES, 18));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Lingsha.java
+++ b/StarRailBattleSim/src/characters/Lingsha.java
@@ -6,6 +6,8 @@ import battleLogic.FuYuan;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,12 +30,11 @@ public class Lingsha extends AbstractCharacter {
     public Lingsha() {
         super("Lingsha", 1358, 679, 437, 98, 80, ElementType.FIRE, 110, 100, Path.ABUNDANCE);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusHPPercent = 18;
-        tracesPower.bonusBreakEffect = 37.3f;
-        tracesPower.bonusAtkPercent = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.HP_PERCENT, 18)
+                .addStat(PowerStat.BREAK_EFFECT, 37.3f)
+                .addStat(PowerStat.ATK_PERCENT, 10));
+
         this.hasAttackingUltimate = true;
         this.basicEnergyGain = 30;
 

--- a/StarRailBattleSim/src/characters/Lingsha.java
+++ b/StarRailBattleSim/src/characters/Lingsha.java
@@ -5,7 +5,6 @@ import battleLogic.BattleHelpers;
 import battleLogic.FuYuan;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TracePower;
 
@@ -31,9 +30,9 @@ public class Lingsha extends AbstractCharacter {
         super("Lingsha", 1358, 679, 437, 98, 80, ElementType.FIRE, 110, 100, Path.ABUNDANCE);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.HP_PERCENT, 18)
-                .addStat(PowerStat.BREAK_EFFECT, 37.3f)
-                .addStat(PowerStat.ATK_PERCENT, 10));
+                .setStat(PowerStat.HP_PERCENT, 18)
+                .setStat(PowerStat.BREAK_EFFECT, 37.3f)
+                .setStat(PowerStat.ATK_PERCENT, 10));
 
         this.hasAttackingUltimate = true;
         this.basicEnergyGain = 30;

--- a/StarRailBattleSim/src/characters/Moze.java
+++ b/StarRailBattleSim/src/characters/Moze.java
@@ -4,7 +4,6 @@ import battleLogic.Battle;
 import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TempPower;
 import powers.TracePower;
@@ -29,9 +28,9 @@ public class Moze extends AbstractCharacter {
         super("Moze", 811, 547, 353, 114, 80, ElementType.LIGHTNING, 120, 75, Path.HUNT);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 18)
-                .addStat(PowerStat.CRIT_DAMAGE, 37.3f)
-                .addStat(PowerStat.HP_PERCENT, 10));
+                .setStat(PowerStat.ATK_PERCENT, 18)
+                .setStat(PowerStat.CRIT_DAMAGE, 37.3f)
+                .setStat(PowerStat.HP_PERCENT, 10));
         this.hasAttackingUltimate = true;
 
         preyPower = new MozePreyPower();

--- a/StarRailBattleSim/src/characters/Moze.java
+++ b/StarRailBattleSim/src/characters/Moze.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,12 +28,10 @@ public class Moze extends AbstractCharacter {
     public Moze() {
         super("Moze", 811, 547, 353, 114, 80, ElementType.LIGHTNING, 120, 75, Path.HUNT);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 18;
-        tracesPower.bonusCritDamage = 37.3f;
-        tracesPower.bonusHPPercent = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 18)
+                .addStat(PowerStat.CRIT_DAMAGE, 37.3f)
+                .addStat(PowerStat.HP_PERCENT, 10));
         this.hasAttackingUltimate = true;
 
         preyPower = new MozePreyPower();
@@ -84,11 +84,7 @@ public class Moze extends AbstractCharacter {
         types.add(DamageType.FOLLOW_UP);
         BattleHelpers.PreAttackLogic(this, types);
 
-        TempPower dmgBonus = new TempPower();
-        dmgBonus.bonusDamageBonus = 30;
-        dmgBonus.turnDuration = 2;
-        dmgBonus.name = "Moze Damage Bonus";
-        addPower(dmgBonus);
+        addPower(TempPower.create(PowerStat.DAMAGE_BONUS, 30, 2, "Moze Damage Bonus"));
 
         AbstractEnemy enemy;
         if (Battle.battle.enemyTeam.size() >= 3) {

--- a/StarRailBattleSim/src/characters/Pela.java
+++ b/StarRailBattleSim/src/characters/Pela.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -17,12 +19,10 @@ public class Pela extends AbstractCharacter {
     public Pela() {
         super(NAME, 988, 547, 463, 105, 80, ElementType.ICE, 110, 100, Path.NIHILITY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 18;
-        tracesPower.bonusSameElementDamageBonus = 22.4f;
-        tracesPower.bonusEffectHit = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 18)
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .addStat(PowerStat.EFFECT_HIT, 10));
         this.hasAttackingUltimate = true;
     }
 
@@ -69,10 +69,7 @@ public class Pela extends AbstractCharacter {
 
         for (AbstractEnemy enemy : Battle.battle.enemyTeam) {
             BattleHelpers.hitEnemy(this, enemy, 1.08f, BattleHelpers.MultiplierStat.ATK, types, TOUGHNESS_DAMAGE_TWO_UNITS);
-            TempPower exposed = new TempPower();
-            exposed.turnDuration = 2;
-            exposed.defenseReduction = 42;
-            exposed.name = ULT_DEBUFF_NAME;
+            TempPower exposed = TempPower.create(PowerStat.DEFENSE_REDUCTION, 42, 2, ULT_DEBUFF_NAME);
             exposed.type = AbstractPower.PowerType.DEBUFF;
             enemy.addPower(exposed);
         }
@@ -104,10 +101,7 @@ public class Pela extends AbstractCharacter {
         BattleHelpers.hitEnemy(this, Battle.battle.getRandomEnemy(), 0.8f, BattleHelpers.MultiplierStat.ATK, types, TOUGHNESS_DAMAGE_TWO_UNITS);
 
         for (AbstractEnemy enemy : Battle.battle.enemyTeam) {
-            TempPower techniqueExposed = new TempPower();
-            techniqueExposed.turnDuration = 2;
-            techniqueExposed.defenseReduction = 20;
-            techniqueExposed.name = "Pela Technique Def Reduction";
+            TempPower techniqueExposed = TempPower.create(PowerStat.DEFENSE_REDUCTION, 20, 2, "Pela Technique Def Reduction");
             techniqueExposed.type = AbstractPower.PowerType.DEBUFF;
             enemy.addPower(techniqueExposed);
         }

--- a/StarRailBattleSim/src/characters/Pela.java
+++ b/StarRailBattleSim/src/characters/Pela.java
@@ -4,7 +4,6 @@ import battleLogic.Battle;
 import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TempPower;
 import powers.TracePower;
@@ -20,9 +19,9 @@ public class Pela extends AbstractCharacter {
         super(NAME, 988, 547, 463, 105, 80, ElementType.ICE, 110, 100, Path.NIHILITY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 18)
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
-                .addStat(PowerStat.EFFECT_HIT, 10));
+                .setStat(PowerStat.ATK_PERCENT, 18)
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .setStat(PowerStat.EFFECT_HIT, 10));
         this.hasAttackingUltimate = true;
     }
 

--- a/StarRailBattleSim/src/characters/Robin.java
+++ b/StarRailBattleSim/src/characters/Robin.java
@@ -34,9 +34,9 @@ public class Robin extends AbstractCharacter {
         this.skillEnergyGain = 35;
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.HP_PERCENT, 18)
-                .addStat(PowerStat.FLAT_SPEED, 5));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.HP_PERCENT, 18)
+                .setStat(PowerStat.FLAT_SPEED, 5));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Robin.java
+++ b/StarRailBattleSim/src/characters/Robin.java
@@ -7,15 +7,19 @@ import battleLogic.Concerto;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Robin extends AbstractCharacter {
-    PermPower skillPower;
-    RobinUltPower ultPower;
-    RobinFixedCritPower fixedCritPower;
+
+    PermPower skillPower = PermPower.create(PowerStat.DAMAGE_BONUS, 50, "Robin Skill Power");
+    RobinUltPower ultPower = new RobinUltPower();
+    RobinFixedCritPower fixedCritPower = new RobinFixedCritPower();
+
     private int skillCounter = 0;
     private int allyAttacksMetric = 0;
     private int concertoProcs = 0;
@@ -28,19 +32,11 @@ public class Robin extends AbstractCharacter {
         super(NAME, 1281, 640, 485, 102, 80, ElementType.PHYSICAL, 160, 100, Path.HARMONY);
 
         this.skillEnergyGain = 35;
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28;
-        tracesPower.bonusHPPercent = 18;
-        tracesPower.bonusFlatSpeed = 5;
-        this.addPower(tracesPower);
 
-        skillPower = new PermPower();
-        skillPower.bonusDamageBonus = 50;
-        skillPower.name = "Robin Skill Power";
-
-        ultPower = new RobinUltPower();
-        fixedCritPower = new RobinFixedCritPower();
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.HP_PERCENT, 18)
+                .addStat(PowerStat.FLAT_SPEED, 5));
     }
 
     public void useSkill() {
@@ -194,11 +190,10 @@ public class Robin extends AbstractCharacter {
         return list;
     }
 
-    private class RobinTalentPower extends AbstractPower {
+    private class RobinTalentPower extends PermPower {
         public RobinTalentPower() {
             this.name = this.getClass().getSimpleName();
-            lastsForever = true;
-            this.bonusCritDamage = 20;
+            this.setStat(PowerStat.CRIT_DAMAGE, 20);
         }
 
         @Override
@@ -216,17 +211,17 @@ public class Robin extends AbstractCharacter {
 
         public void updateAtkBuff() {
             float atk = getFinalAttackWithoutConcerto();
-            this.bonusFlatAtk = (int)(0.228 * atk) + 200;
+            this.setStat(PowerStat.FLAT_ATK, (int)(0.228 * atk) + 200);
         }
 
         private float getFinalAttackWithoutConcerto() {
             int totalBaseAtk = baseAtk + lightcone.baseAtk;
             float totalBonusAtkPercent = 0;
-            int totalBonusFlatAtk = 0;
+            float totalBonusFlatAtk = 0;
             for (AbstractPower power : powerList) {
                 if (!power.name.equals(this.name)) {
-                    totalBonusAtkPercent += power.bonusAtkPercent;
-                    totalBonusFlatAtk += power.bonusFlatAtk;
+                    totalBonusAtkPercent += power.getStat(PowerStat.ATK_PERCENT);
+                    totalBonusFlatAtk += power.getStat(PowerStat.FLAT_ATK);
                 }
             }
             return (totalBaseAtk * (1 + totalBonusAtkPercent / 100) + totalBonusFlatAtk);

--- a/StarRailBattleSim/src/characters/RuanMei.java
+++ b/StarRailBattleSim/src/characters/RuanMei.java
@@ -5,12 +5,14 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
 public class RuanMei extends AbstractCharacter {
     PermPower skillPower;
-    AbstractPower ultPower;
+    AbstractPower ultPower = new RuanMeiUltPower();
     private int skillCounter = 0;
     private int ultCounter = 0;
     public static final String NAME = "Ruan Mei";
@@ -21,19 +23,14 @@ public class RuanMei extends AbstractCharacter {
     public RuanMei() {
         super(NAME, 1087, 660, 485, 104, 80, ElementType.ICE, 130, 100, Path.HARMONY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusBreakEffect = 37.3f;
-        tracesPower.bonusDefPercent = 22.5f;
-        tracesPower.bonusFlatSpeed = 5;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.BREAK_EFFECT, 37.3f)
+                .addStat(PowerStat.DEF_PERCENT, 22.5f)
+                .addStat(PowerStat.FLAT_SPEED, 5));
 
-        skillPower = new PermPower();
-        skillPower.bonusDamageBonus = 68;
-        skillPower.bonusWeaknessBreakEff = 50;
-        skillPower.name = SKILL_POWER_NAME;
-
-        ultPower = new RuanMeiUltPower();
+        this.skillPower = (PermPower) new PermPower(SKILL_POWER_NAME)
+                .addStat(PowerStat.DAMAGE_BONUS, 68)
+                .addStat(PowerStat.WEAKNESS_BREAK_EFF, 50);
     }
 
     public void useSkill() {
@@ -99,16 +96,10 @@ public class RuanMei extends AbstractCharacter {
 
     public void onCombatStart() {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
-            PermPower breakBuff = new PermPower();
-            breakBuff.bonusBreakEffect = 20;
-            breakBuff.name = "Ruan Mei Break Buff";
-            character.addPower(breakBuff);
+            character.addPower(PermPower.create(PowerStat.BREAK_EFFECT, 20, "Ruan Mei Break Buff"));
 
-            PermPower speedBuff = new PermPower();
-            speedBuff.name = "Ruan Mei Speed Power";
-            speedBuff.bonusSpeedPercent = 10;
             if (character != this) {
-                character.addPower(speedBuff);
+                character.addPower(PermPower.create(PowerStat.SPEED_PERCENT, 10, "Ruan Mei Speed Buff"));
             }
         }
     }
@@ -134,11 +125,10 @@ public class RuanMei extends AbstractCharacter {
         }
     }
 
-    private class RuanMeiUltPower extends AbstractPower {
+    private class RuanMeiUltPower extends PermPower {
         public RuanMeiUltPower() {
-            this.name = ULT_POWER_NAME;
-            this.lastsForever = true;
-            this.resPen = 25;
+            super(ULT_DEBUFF_NAME);
+            this.setStat(PowerStat.RES_PEN, 25);
         }
 
         @Override

--- a/StarRailBattleSim/src/characters/RuanMei.java
+++ b/StarRailBattleSim/src/characters/RuanMei.java
@@ -24,13 +24,13 @@ public class RuanMei extends AbstractCharacter {
         super(NAME, 1087, 660, 485, 104, 80, ElementType.ICE, 130, 100, Path.HARMONY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.BREAK_EFFECT, 37.3f)
-                .addStat(PowerStat.DEF_PERCENT, 22.5f)
-                .addStat(PowerStat.FLAT_SPEED, 5));
+                .setStat(PowerStat.BREAK_EFFECT, 37.3f)
+                .setStat(PowerStat.DEF_PERCENT, 22.5f)
+                .setStat(PowerStat.FLAT_SPEED, 5));
 
         this.skillPower = (PermPower) new PermPower(SKILL_POWER_NAME)
-                .addStat(PowerStat.DAMAGE_BONUS, 68)
-                .addStat(PowerStat.WEAKNESS_BREAK_EFF, 50);
+                .setStat(PowerStat.DAMAGE_BONUS, 68)
+                .setStat(PowerStat.WEAKNESS_BREAK_EFF, 50);
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Sparkle.java
+++ b/StarRailBattleSim/src/characters/Sparkle.java
@@ -21,9 +21,9 @@ public class Sparkle extends AbstractCharacter {
 
         this.basicEnergyGain = 30;
         this.addPower(new TracePower()
-                .addStat(PowerStat.CRIT_DAMAGE, 24)
-                .addStat(PowerStat.HP_PERCENT, 28)
-                .addStat(PowerStat.EFFECT_RES, 10));
+                .setStat(PowerStat.CRIT_DAMAGE, 24)
+                .setStat(PowerStat.HP_PERCENT, 28)
+                .setStat(PowerStat.EFFECT_RES, 10));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Sparkle.java
+++ b/StarRailBattleSim/src/characters/Sparkle.java
@@ -5,6 +5,8 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
+import powers.TracePower;
 
 import java.util.ArrayList;
 
@@ -18,12 +20,10 @@ public class Sparkle extends AbstractCharacter {
         super(NAME, 1397, 524, 485, 101, 80, ElementType.QUANTUM, 110, 100, Path.HARMONY);
 
         this.basicEnergyGain = 30;
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusCritDamage = 24;
-        tracesPower.bonusHPPercent = 28;
-        tracesPower.bonusEffectRes = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.CRIT_DAMAGE, 24)
+                .addStat(PowerStat.HP_PERCENT, 28)
+                .addStat(PowerStat.EFFECT_RES, 10));
     }
 
     public void useSkill() {
@@ -77,9 +77,7 @@ public class Sparkle extends AbstractCharacter {
         Battle.battle.MAX_SKILL_POINTS += 2;
         int numQuantumAllies = 0;
         for (AbstractCharacter character : Battle.battle.playerTeam) {
-            PermPower nocturne = new PermPower();
-            nocturne.bonusAtkPercent = 15;
-            nocturne.name = "Sparkle Atk Bonus";
+            PermPower nocturne = PermPower.create(PowerStat.ATK_PERCENT, 15, "Sparkle Atk Bonus");
             character.addPower(nocturne);
             if (character.elementType == ElementType.QUANTUM) {
                 numQuantumAllies++;
@@ -95,9 +93,7 @@ public class Sparkle extends AbstractCharacter {
         }
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             if (character.elementType == ElementType.QUANTUM) {
-                PermPower quantumNocturne = new PermPower();
-                quantumNocturne.bonusAtkPercent = quantumAtkBonus;
-                quantumNocturne.name = "Sparkle Quantum Atk Bonus";
+                PermPower quantumNocturne = PermPower.create(PowerStat.ATK_PERCENT, quantumAtkBonus, "Sparkle Quantum Atk Bonus");
                 character.addPower(quantumNocturne);
             }
         }
@@ -107,12 +103,11 @@ public class Sparkle extends AbstractCharacter {
         Battle.battle.generateSkillPoint(this, 3);
     }
 
-    private class SparkleSkillPower extends AbstractPower {
+    private class SparkleSkillPower extends PermPower {
         public SparkleSkillPower() {
-            this.name = SKILL_POWER_NAME;
-            this.lastsForever = true;
+            super(SKILL_POWER_NAME);
             this.justApplied = true;
-            this.bonusCritDamage = (getTotalCritDamage() * 0.24f) + 45;
+            this.setStat(PowerStat.CRIT_DAMAGE, (getTotalCritDamage() * 0.24f) + 45);
         }
 
         @Override

--- a/StarRailBattleSim/src/characters/SwordMarch.java
+++ b/StarRailBattleSim/src/characters/SwordMarch.java
@@ -5,8 +5,10 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TauntPower;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,12 +34,10 @@ public class SwordMarch extends AbstractCharacter {
     public SwordMarch() {
         super("Sword March", 1058, 564, 441, 102, 80, ElementType.IMAGINARY, 110, 75, Path.HUNT);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28f;
-        tracesPower.bonusCritDamage = 24f;
-        tracesPower.bonusDefPercent = 12.5f;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.CRIT_DAMAGE, 24)
+                .addStat(PowerStat.DEF_PERCENT, 12.5f));
         this.hasAttackingUltimate = true;
     }
 
@@ -48,11 +48,7 @@ public class SwordMarch extends AbstractCharacter {
                 master = character;
                 AbstractPower masterPower = new MarchMasterPower();
                 Battle.battle.IncreaseSpeed(master, masterPower);
-
-                PermPower marchSpeedBoost = new PermPower();
-                marchSpeedBoost.bonusSpeedPercent = 10;
-                marchSpeedBoost.name = "March Speed Boost";
-                Battle.battle.IncreaseSpeed(this, marchSpeedBoost);
+                Battle.battle.IncreaseSpeed(this, PermPower.create(PowerStat.SPEED_PERCENT, 10, "March Speed Boost"));
             }
         }
     }
@@ -98,12 +94,13 @@ public class SwordMarch extends AbstractCharacter {
         int initialHits = 3;
         int numExtraHits = 0;
         int procChance = 60;
-        TempPower ultCritDmgBuff = new TempPower();
-        ultCritDmgBuff.bonusCritDamage = 50;
-        ultCritDmgBuff.name = "March Ult Crit Dmg Buff";
-        TempPower ebaDamageBonus = new TempPower();
-        ebaDamageBonus.bonusDamageBonus = 88;
-        ebaDamageBonus.name = "March Enhanced Basic Damage Bonus";
+
+        TempPower ultCritDmgBuff = new TempPower("March Ult Crit Dmg Buff");
+        ultCritDmgBuff.setStat(PowerStat.CRIT_DAMAGE, 50);
+
+        TempPower ebaDamageBonus = new TempPower("March Enhanced Basic Damage Bonus");
+        ebaDamageBonus.setStat(PowerStat.DAMAGE_BONUS, 88);
+
         addPower(ebaDamageBonus);
         if (hasUltEnhancement) {
             initialHits += 2;
@@ -132,11 +129,7 @@ public class SwordMarch extends AbstractCharacter {
         removePower(ebaDamageBonus);
         isEnhanced = false;
 
-        TempPower ebaMasterBuff = new TempPower();
-        ebaMasterBuff.bonusCritDamage = 60;
-        ebaMasterBuff.turnDuration = 2;
-        ebaMasterBuff.name = "Enhanced Basic Master Buff";
-        master.addPower(ebaMasterBuff);
+        master.addPower(TempPower.create(PowerStat.CRIT_DAMAGE, 60, 2,"Enhanced Basic Master Buff"));
 
         BattleHelpers.PostAttackLogic(this, types);
     }
@@ -244,11 +237,10 @@ public class SwordMarch extends AbstractCharacter {
         return list;
     }
 
-    private class MarchMasterPower extends AbstractPower {
+    private class MarchMasterPower extends PermPower {
         public MarchMasterPower() {
             this.name = this.getClass().getSimpleName();
-            this.bonusSpeedPercent = 10.8f;
-            this.lastsForever = true;
+            this.setStat(PowerStat.SPEED_PERCENT, 10.8f);
         }
 
         @Override

--- a/StarRailBattleSim/src/characters/SwordMarch.java
+++ b/StarRailBattleSim/src/characters/SwordMarch.java
@@ -6,7 +6,6 @@ import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
 import powers.PowerStat;
-import powers.TauntPower;
 import powers.TempPower;
 import powers.TracePower;
 
@@ -35,9 +34,9 @@ public class SwordMarch extends AbstractCharacter {
         super("Sword March", 1058, 564, 441, 102, 80, ElementType.IMAGINARY, 110, 75, Path.HUNT);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.CRIT_DAMAGE, 24)
-                .addStat(PowerStat.DEF_PERCENT, 12.5f));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.CRIT_DAMAGE, 24)
+                .setStat(PowerStat.DEF_PERCENT, 12.5f));
         this.hasAttackingUltimate = true;
     }
 

--- a/StarRailBattleSim/src/characters/Tingyun.java
+++ b/StarRailBattleSim/src/characters/Tingyun.java
@@ -5,7 +5,9 @@ import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,12 +22,10 @@ public class Tingyun extends AbstractCharacter {
     public Tingyun() {
         super("Tingyun", 847, 529, 397, 112, 80, ElementType.LIGHTNING, 130, 100, Path.HARMONY);
 
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28;
-        tracesPower.bonusDefPercent = 22.5f;
-        tracesPower.bonusSameElementDamageBonus = 8;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.DEF_PERCENT, 22.5f)
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 8));
     }
 
     public void useSkill() {
@@ -38,11 +38,8 @@ public class Tingyun extends AbstractCharacter {
             }
         }
 
-        TempPower speedPower = new TempPower();
-        speedPower.bonusSpeedPercent = 20;
-        speedPower.turnDuration = 1;
+        TempPower speedPower = TempPower.create(PowerStat.SPEED_PERCENT, 20, 1, "Tingyun Skill Speed Power");
         speedPower.justApplied = true;
-        speedPower.name = "Tingyun Skill Speed Power";
         Battle.battle.IncreaseSpeed(this, speedPower);
     }
     public void useBasicAttack() {
@@ -72,11 +69,7 @@ public class Tingyun extends AbstractCharacter {
         for (AbstractCharacter character : Battle.battle.playerTeam) {
             if (character.isDPS && character.currentEnergy < character.maxEnergy) {
                 character.increaseEnergy(60, false);
-                TempPower ultDamageBonus = new TempPower();
-                ultDamageBonus.bonusDamageBonus = 56;
-                ultDamageBonus.turnDuration = 2;
-                ultDamageBonus.name = "Tingyun Ult Damage Bonus";
-                character.addPower(ultDamageBonus);
+                character.addPower(TempPower.create(PowerStat.DAMAGE_BONUS, 56, 2, "Tingyun Ult Damage Bonus"));
                 break;
             }
         }
@@ -121,11 +114,12 @@ public class Tingyun extends AbstractCharacter {
         return list;
     }
 
-    private class TingyunSkillPower extends AbstractPower {
+    private class TingyunSkillPower extends TempPower {
         public TingyunSkillPower() {
+            super(3);
+
             this.name = this.getClass().getSimpleName();
-            this.bonusAtkPercent = 55;
-            this.turnDuration = 3;
+            this.setStat(PowerStat.ATK_PERCENT, 55);
         }
 
         public void onAttack(AbstractCharacter character, ArrayList<AbstractEnemy> enemiesHit, ArrayList<AbstractCharacter.DamageType> types) {
@@ -136,11 +130,7 @@ public class Tingyun extends AbstractCharacter {
 
         public void onUseUltimate() {
             if (benefactor != null) {
-                TempPower speedPower = new TempPower();
-                speedPower.bonusSpeedPercent = 20;
-                speedPower.turnDuration = 1;
-                speedPower.name = "Tingyun E1 Speed Power";
-                Battle.battle.IncreaseSpeed(benefactor, speedPower);
+                Battle.battle.IncreaseSpeed(benefactor, TempPower.create(PowerStat.SPEED_PERCENT, 20, 1, "Tingyun E1 Speed Power"));
             }
         }
 

--- a/StarRailBattleSim/src/characters/Tingyun.java
+++ b/StarRailBattleSim/src/characters/Tingyun.java
@@ -4,7 +4,6 @@ import battleLogic.Battle;
 import battleLogic.BattleHelpers;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
-import powers.PermPower;
 import powers.PowerStat;
 import powers.TempPower;
 import powers.TracePower;
@@ -23,9 +22,9 @@ public class Tingyun extends AbstractCharacter {
         super("Tingyun", 847, 529, 397, 112, 80, ElementType.LIGHTNING, 130, 100, Path.HARMONY);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.DEF_PERCENT, 22.5f)
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 8));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.DEF_PERCENT, 22.5f)
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 8));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Topaz.java
+++ b/StarRailBattleSim/src/characters/Topaz.java
@@ -6,12 +6,14 @@ import battleLogic.Numby;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class Topaz extends AbstractCharacter {
-    AbstractPower proofOfDebt;
+    AbstractPower proofOfDebt = new ProofOfDebt();
     Numby numby;
     PermPower stonksPower;
     private int ultCounter = 0;
@@ -29,14 +31,10 @@ public class Topaz extends AbstractCharacter {
     public Topaz() {
         super("Topaz", 931, 621, 412, 110, 80, ElementType.FIRE, 130, 75, Path.HUNT);
 
-        proofOfDebt = new ProofOfDebt();
-
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusSameElementDamageBonus = 22.4f;
-        tracesPower.bonusCritChance = 12.0f;
-        tracesPower.bonusHPPercent = 10;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .addStat(PowerStat.CRIT_CHANCE, 12.0f)
+                .addStat(PowerStat.HP_PERCENT, 10));
 
         this.addPower(new FireWeaknessBonusDamage());
 
@@ -92,11 +90,9 @@ public class Topaz extends AbstractCharacter {
         // only ult if numby isn't about to spin so we don't waste action forward as much
         if (Battle.battle.actionValueMap.get(numby) >= numby.getBaseAV() * 0.25) {
             super.useUltimate();
-            stonksPower = new PermPower();
-            stonksPower.bonusCritDamage = 25;
-            stonksPower.name = "Topaz Ult Power";
+            this.stonksPower = PermPower.create(PowerStat.CRIT_DAMAGE, 25, "Topaz Ult Power");
             ultCounter = 2;
-            addPower(stonksPower);
+            this.addPower(this.stonksPower);
         }
     }
 

--- a/StarRailBattleSim/src/characters/Topaz.java
+++ b/StarRailBattleSim/src/characters/Topaz.java
@@ -32,9 +32,9 @@ public class Topaz extends AbstractCharacter {
         super("Topaz", 931, 621, 412, 110, 80, ElementType.FIRE, 130, 75, Path.HUNT);
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
-                .addStat(PowerStat.CRIT_CHANCE, 12.0f)
-                .addStat(PowerStat.HP_PERCENT, 10));
+                .setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, 22.4f)
+                .setStat(PowerStat.CRIT_CHANCE, 12.0f)
+                .setStat(PowerStat.HP_PERCENT, 10));
 
         this.addPower(new FireWeaknessBonusDamage());
 

--- a/StarRailBattleSim/src/characters/Yunli.java
+++ b/StarRailBattleSim/src/characters/Yunli.java
@@ -37,9 +37,9 @@ public class Yunli extends AbstractCharacter {
         this.isDPS = true;
 
         this.addPower(new TracePower()
-                .addStat(PowerStat.ATK_PERCENT, 28)
-                .addStat(PowerStat.CRIT_CHANCE, 6.7f)
-                .addStat(PowerStat.HP_PERCENT, 18));
+                .setStat(PowerStat.ATK_PERCENT, 28)
+                .setStat(PowerStat.CRIT_CHANCE, 6.7f)
+                .setStat(PowerStat.HP_PERCENT, 18));
     }
 
     public void useSkill() {

--- a/StarRailBattleSim/src/characters/Yunli.java
+++ b/StarRailBattleSim/src/characters/Yunli.java
@@ -6,8 +6,10 @@ import enemies.AbstractEnemy;
 import lightcones.destruction.DanceAtSunset;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 import powers.TauntPower;
 import powers.TempPower;
+import powers.TracePower;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,8 +17,8 @@ import java.util.HashMap;
 public class Yunli extends AbstractCharacter {
 
     public boolean isParrying;
-    AbstractPower cullPower;
-    AbstractPower techniqueDamageBonus;
+    AbstractPower cullPower = new CullCritDamageBuff();
+    AbstractPower techniqueDamageBonus = PermPower.create(PowerStat.DAMAGE_BONUS, 80, "Technique Damage Bonus");
     AbstractPower tauntPower = new TauntPower(this);
 
     private int numNormalCounters = 0;
@@ -34,18 +36,10 @@ public class Yunli extends AbstractCharacter {
         this.ultCost = 120;
         this.isDPS = true;
 
-        cullPower = new CullCritDamageBuff();
-
-        techniqueDamageBonus = new PermPower();
-        techniqueDamageBonus.bonusDamageBonus = 80;
-        techniqueDamageBonus.name = "Technique Damage Bonus";
-
-        PermPower tracesPower = new PermPower();
-        tracesPower.name = "Traces Stat Bonus";
-        tracesPower.bonusAtkPercent = 28;
-        tracesPower.bonusCritChance = 6.7f;
-        tracesPower.bonusHPPercent = 18;
-        this.addPower(tracesPower);
+        this.addPower(new TracePower()
+                .addStat(PowerStat.ATK_PERCENT, 28)
+                .addStat(PowerStat.CRIT_CHANCE, 6.7f)
+                .addStat(PowerStat.HP_PERCENT, 18));
     }
 
     public void useSkill() {
@@ -205,11 +199,7 @@ public class Yunli extends AbstractCharacter {
     }
 
     public AbstractPower getTrueSunderPower() {
-        TempPower trueSunderAtkBonus = new TempPower();
-        trueSunderAtkBonus.bonusAtkPercent = 30;
-        trueSunderAtkBonus.turnDuration = 1;
-        trueSunderAtkBonus.name = "True Sunder Atk Bonus";
-        return trueSunderAtkBonus;
+        return TempPower.create(PowerStat.ATK_PERCENT, 30, 1, "True Sunder Atk Bonus");
     }
 
     public HashMap<String, String> getCharacterSpecificMetricMap() {

--- a/StarRailBattleSim/src/enemies/AbstractEnemy.java
+++ b/StarRailBattleSim/src/enemies/AbstractEnemy.java
@@ -7,6 +7,7 @@ import characters.AbstractCharacter;
 import characters.Moze;
 import characters.RuanMei;
 import powers.AbstractPower;
+import powers.PowerStat;
 import powers.TauntPower;
 
 import java.util.ArrayList;
@@ -66,18 +67,18 @@ public abstract class AbstractEnemy extends AbstractEntity {
         int totalBonusAtkPercent = 0;
         int totalBonusFlatAtk = 0;
         for (AbstractPower power : powerList) {
-            totalBonusAtkPercent += power.bonusAtkPercent;
-            totalBonusFlatAtk += power.bonusFlatAtk;
+            totalBonusAtkPercent += power.getStat(PowerStat.ATK_PERCENT);
+            totalBonusFlatAtk += power.getStat(PowerStat.FLAT_ATK);
         }
-        return (int) (totalBaseAtk * (1 + (float)totalBonusAtkPercent / 100) + totalBonusFlatAtk);
+        return (int) (totalBaseAtk * (1 + totalBonusAtkPercent / 100) + totalBonusFlatAtk);
     }
 
     public float getFinalDefense() {
         float totalDefenseBonus = 0;
         float totalDefenseReduction = 0;
         for (AbstractPower power : powerList) {
-            totalDefenseBonus += power.bonusDefPercent;
-            totalDefenseReduction += power.defenseReduction;
+            totalDefenseBonus += power.getStat(PowerStat.DEF_PERCENT);
+            totalDefenseReduction += power.getStat(PowerStat.DEFENSE_REDUCTION);
         }
         return totalDefenseBonus - totalDefenseReduction;
     }

--- a/StarRailBattleSim/src/lightcones/DefaultLightcone.java
+++ b/StarRailBattleSim/src/lightcones/DefaultLightcone.java
@@ -1,0 +1,9 @@
+package lightcones;
+
+import characters.AbstractCharacter;
+
+public class DefaultLightcone extends AbstractLightcone{
+    public DefaultLightcone(AbstractCharacter owner) {
+        super(0, 0, 0, owner);
+    }
+}

--- a/StarRailBattleSim/src/lightcones/destruction/DanceAtSunset.java
+++ b/StarRailBattleSim/src/lightcones/destruction/DanceAtSunset.java
@@ -5,6 +5,7 @@ import enemies.AbstractEnemy;
 import lightcones.AbstractLightcone;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -18,8 +19,8 @@ public class DanceAtSunset extends AbstractLightcone {
     public void onEquip() {
         PermPower statBonus = new PermPower();
         statBonus.name = "Dance At Sunset Stat Bonus";
-        statBonus.bonusCritDamage = 36;
-        statBonus.bonusTauntValue = 500;
+        statBonus.setStat(PowerStat.CRIT_DAMAGE, 36);
+        statBonus.setStat(PowerStat.TAUNT_VALUE, 500);
         owner.addPower(statBonus);
     }
 

--- a/StarRailBattleSim/src/lightcones/harmony/ButTheBattleIsntOver.java
+++ b/StarRailBattleSim/src/lightcones/harmony/ButTheBattleIsntOver.java
@@ -4,9 +4,9 @@ import battleLogic.Battle;
 import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import lightcones.AbstractLightcone;
-import powers.AbstractPower;
 import powers.PermPower;
 import powers.PowerStat;
+import powers.TempPower;
 
 /**
  * This lightcone assumes onSpecificTrigger is called when the character uses their skill, and that
@@ -26,7 +26,7 @@ public class ButTheBattleIsntOver extends AbstractLightcone  {
     public void onSpecificTrigger(AbstractCharacter character, AbstractEnemy enemy) {
         if (character == null) return;
 
-        character.addPower(new BattleIsntOverBoost());
+        character.addPower(TempPower.create(PowerStat.DAMAGE_BONUS, 30, 1, "But The Battle Isn't Over Damage Boost"));
     }
 
     @Override
@@ -34,14 +34,6 @@ public class ButTheBattleIsntOver extends AbstractLightcone  {
         // Metric is incremented before hook is called, so there is an offset.
         if (this.owner.numUltsMetric % 2 == 1) {
             Battle.battle.generateSkillPoint(this.owner, 1);
-        }
-    }
-
-    public static class BattleIsntOverBoost extends AbstractPower {
-        public BattleIsntOverBoost() {
-            this.name = this.getClass().getSimpleName();
-            this.turnDuration = 1;
-            this.bonusDamageBonus = 30;
         }
     }
 }

--- a/StarRailBattleSim/src/lightcones/harmony/PastAndFuture.java
+++ b/StarRailBattleSim/src/lightcones/harmony/PastAndFuture.java
@@ -3,7 +3,8 @@ package lightcones.harmony;
 import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import lightcones.AbstractLightcone;
-import powers.AbstractPower;
+import powers.PowerStat;
+import powers.TempPower;
 
 /**
  * Assumes onSpecificTrigger is called on skill, with the character as next to act
@@ -17,19 +18,11 @@ public class PastAndFuture extends AbstractLightcone {
 
     public void onSpecificTrigger(AbstractCharacter character, AbstractEnemy enemy) {
         if (character != null) {
-            character.addPower(new PastAndFutureDamagePower());
+            character.addPower(TempPower.create(PowerStat.DAMAGE_BONUS, 32, 1, "Past and Future Damage Boost"));
         }
     }
 
     public String toString() {
         return "Past and Future";
-    }
-
-    private static class PastAndFutureDamagePower extends AbstractPower {
-        public PastAndFutureDamagePower() {
-            this.name = this.getClass().getSimpleName();
-            this.turnDuration = 1;
-            this.bonusDamageBonus = 32;
-        }
     }
 }

--- a/StarRailBattleSim/src/lightcones/nihility/ThoseManySprings.java
+++ b/StarRailBattleSim/src/lightcones/nihility/ThoseManySprings.java
@@ -42,9 +42,8 @@ public class ThoseManySprings extends AbstractLightcone {
         public static final String NAME = "Unarmored";
 
         public Unarmored() {
-            this.name = NAME;
-            this.turnDuration = 2;
-            this.bonusDamageTaken = 10;
+            super(2, NAME);
+            this.setStat(PowerStat.DAMAGE_TAKEN, 10);
             this.type = PowerType.DEBUFF;
         }
     }
@@ -53,9 +52,8 @@ public class ThoseManySprings extends AbstractLightcone {
         public static final String NAME = "Cornered";
 
         public Cornered() {
-            this.name = NAME;
-            this.turnDuration = 2;
-            this.bonusDamageTaken = 24;
+            super(2, NAME);
+            this.setStat(PowerStat.DAMAGE_TAKEN, 24);
             this.type = PowerType.DEBUFF;
         }
     }

--- a/StarRailBattleSim/src/lightcones/preservation/InherentlyUnjustDestiny.java
+++ b/StarRailBattleSim/src/lightcones/preservation/InherentlyUnjustDestiny.java
@@ -6,6 +6,7 @@ import lightcones.AbstractLightcone;
 import powers.AbstractPower;
 import powers.PermPower;
 import powers.PowerStat;
+import powers.TempPower;
 
 import java.util.ArrayList;
 
@@ -34,12 +35,12 @@ public class InherentlyUnjustDestiny extends AbstractLightcone {
         }
     }
 
-    public static class FollowDmgBonus extends AbstractPower {
+    public static class FollowDmgBonus extends TempPower {
         public FollowDmgBonus() {
+            super(2);
             this.name = this.getClass().getSimpleName();
-            this.turnDuration = 2;
             this.type = PowerType.DEBUFF;
-            this.bonusDamageTaken = 10;
+            this.setStat(PowerStat.DAMAGE_TAKEN, 10);
         }
     }
 

--- a/StarRailBattleSim/src/lightcones/preservation/MomentOfVictory.java
+++ b/StarRailBattleSim/src/lightcones/preservation/MomentOfVictory.java
@@ -22,9 +22,6 @@ public class MomentOfVictory extends AbstractLightcone {
 
     @Override
     public void onAttacked(AbstractEnemy enemy) {
-        TempPower defBoost = new TempPower();
-        defBoost.name = "MomentOfVictory#onAttacked";
-        defBoost.bonusDefPercent = 24;
-        this.owner.addPower(defBoost);
+        this.owner.addPower(TempPower.create(PowerStat.DEF_PERCENT, 24, 1, "Moment Of Victory Defense Boost"));
     }
 }

--- a/StarRailBattleSim/src/powers/AbstractPower.java
+++ b/StarRailBattleSim/src/powers/AbstractPower.java
@@ -2,10 +2,12 @@ package powers;
 
 import battleLogic.AbstractEntity;
 import characters.AbstractCharacter;
+import com.sun.istack.internal.NotNull;
 import enemies.AbstractEnemy;
-import relics.RelicStats;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class AbstractPower {
 
@@ -15,29 +17,8 @@ public abstract class AbstractPower {
 
     public String name;
 
-    public float bonusFlatHP;
-    public float bonusHPPercent;
-    public float bonusFlatAtk;
-    public float bonusAtkPercent;
-    public float bonusFlatDef;
-    public float bonusDefPercent;
-    public float bonusFlatSpeed;
-    public float bonusSpeedPercent;
-    public float bonusSameElementDamageBonus;
-    public float bonusEffectHit;
-    public float bonusEffectRes;
-    public float bonusBreakEffect;
-    public float bonusHealing;
-    public float bonusDamageBonus;
-    public float bonusDamageTaken;
-    public float defenseReduction;
-    public float defenseIgnore;
-    public float resPen;
-    public float bonusCritChance;
-    public float bonusCritDamage;
-    public float bonusEnergyRegen;
-    public float bonusTauntValue;
-    public float bonusWeaknessBreakEff;
+    private final Map<PowerStat, Float> stats = new HashMap<>();
+
     public int turnDuration;
     public PowerType type = PowerType.BUFF;
     public boolean durationBasedOnSelfTurns = true;
@@ -46,6 +27,13 @@ public abstract class AbstractPower {
     public int maxStacks = 0;
     public int stacks = 1;
     public AbstractEntity owner;
+
+    public AbstractPower() {
+    }
+
+    public AbstractPower(String name) {
+        this.name = name;
+    }
 
     public float getConditionalAtkBonus(AbstractCharacter character) {
         return 0;
@@ -135,133 +123,43 @@ public abstract class AbstractPower {
 
     }
 
+    /**
+     * Get the value of a stat
+     * @param stat The stat to get
+     * @return The value of the stat, 0 if the stat is not set
+     */
+    @NotNull
     public float getStat(PowerStat stat) {
-        switch (stat) {
-            case FLAT_HP:
-                return this.bonusFlatHP;
-            case HP_PERCENT:
-                return this.bonusHPPercent;
-            case FLAT_ATK:
-                return this.bonusFlatAtk;
-            case ATK_PERCENT:
-                return this.bonusAtkPercent;
-            case FLAT_DEF:
-                return this.bonusFlatDef;
-            case DEF_PERCENT:
-                return this.bonusDefPercent;
-            case FLAT_SPEED:
-                return this.bonusFlatSpeed;
-            case SPEED_PERCENT:
-                return this.bonusSpeedPercent;
-            case SAME_ELEMENT_DAMAGE_BONUS:
-                return this.bonusSameElementDamageBonus;
-            case EFFECT_HIT:
-                return this.bonusEffectHit;
-            case EFFECT_RES:
-                return this.bonusEffectRes;
-            case BREAK_EFFECT:
-                return this.bonusBreakEffect;
-            case HEALING:
-                return this.bonusHealing;
-            case DAMAGE_BONUS:
-                return this.bonusDamageBonus;
-            case DAMAGE_TAKEN:
-                return this.bonusDamageTaken;
-            case DEFENSE_REDUCTION:
-                return this.defenseReduction;
-            case DEFENSE_IGNORE:
-                return this.defenseIgnore;
-            case RES_PEN:
-                return this.resPen;
-            case CRIT_CHANCE:
-                return this.bonusCritChance;
-            case CRIT_DAMAGE:
-                return this.bonusCritDamage;
-            case ENERGY_REGEN:
-                return this.bonusEnergyRegen;
-            case TAUNT_VALUE:
-                return this.bonusTauntValue;
-            case WEAKNESS_BREAK_EFF:
-                return this.bonusWeaknessBreakEff;
-            default:
-                throw new IllegalArgumentException("Unknown stat: " + stat);
-        }
+        return this.stats.getOrDefault(stat, 0f);
     }
 
+    /**
+     * Increase the value of a stat, calls getStat internally
+     * @param stat The stat to increase
+     * @param value The value to increase by
+     */
+    public void increaseStat(PowerStat stat, float value) {
+        this.setStat(stat, this.getStat(stat) + value);
+    }
+
+    /**
+     * Add a value to a stat, calls setStat internally, for chaining.
+     * @param stat The stat to add to
+     * @param value The value to add
+     * @return The power object
+     */
+    public AbstractPower addStat(PowerStat stat, float value) {
+        this.setStat(stat, value);
+        return this;
+    }
+
+    /**
+     * Set the value of a stat, this overwrites the previous value
+     * @param stat The stat to set
+     * @param value The value to set
+     */
     public void setStat(PowerStat stat, float value) {
-        switch (stat) {
-            case FLAT_HP:
-                this.bonusFlatHP = value;
-                break;
-            case HP_PERCENT:
-                this.bonusHPPercent = value;
-                break;
-            case FLAT_ATK:
-                this.bonusFlatAtk = value;
-                break;
-            case ATK_PERCENT:
-                this.bonusAtkPercent = value;
-                break;
-            case FLAT_DEF:
-                this.bonusFlatDef = value;
-                break;
-            case DEF_PERCENT:
-                this.bonusDefPercent = value;
-                break;
-            case FLAT_SPEED:
-                this.bonusFlatSpeed = value;
-                break;
-            case SPEED_PERCENT:
-                this.bonusSpeedPercent = value;
-                break;
-            case SAME_ELEMENT_DAMAGE_BONUS:
-                this.bonusSameElementDamageBonus = value;
-                break;
-            case EFFECT_HIT:
-                this.bonusEffectHit = value;
-                break;
-            case EFFECT_RES:
-                this.bonusEffectRes = value;
-                break;
-            case BREAK_EFFECT:
-                this.bonusBreakEffect = value;
-                break;
-            case HEALING:
-                this.bonusHealing = value;
-                break;
-            case DAMAGE_BONUS:
-                this.bonusDamageBonus = value;
-                break;
-            case DAMAGE_TAKEN:
-                this.bonusDamageTaken = value;
-                break;
-            case DEFENSE_REDUCTION:
-                this.defenseReduction = value;
-                break;
-            case DEFENSE_IGNORE:
-                this.defenseIgnore = value;
-                break;
-            case RES_PEN:
-                this.resPen = value;
-                break;
-            case CRIT_CHANCE:
-                this.bonusCritChance = value;
-                break;
-            case CRIT_DAMAGE:
-                this.bonusCritDamage = value;
-                break;
-            case ENERGY_REGEN:
-                this.bonusEnergyRegen = value;
-                break;
-            case TAUNT_VALUE:
-                this.bonusTauntValue = value;
-                break;
-            case WEAKNESS_BREAK_EFF:
-                this.bonusWeaknessBreakEff = value;
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown stat: " + stat);
-        }
+        this.stats.put(stat, value);
     }
 
 }

--- a/StarRailBattleSim/src/powers/AbstractPower.java
+++ b/StarRailBattleSim/src/powers/AbstractPower.java
@@ -143,23 +143,14 @@ public abstract class AbstractPower {
     }
 
     /**
-     * Add a value to a stat, calls setStat internally, for chaining.
-     * @param stat The stat to add to
-     * @param value The value to add
-     * @return The power object
-     */
-    public AbstractPower addStat(PowerStat stat, float value) {
-        this.setStat(stat, value);
-        return this;
-    }
-
-    /**
      * Set the value of a stat, this overwrites the previous value
      * @param stat The stat to set
      * @param value The value to set
+     * @return The power object
      */
-    public void setStat(PowerStat stat, float value) {
+    public AbstractPower setStat(PowerStat stat, float value) {
         this.stats.put(stat, value);
+        return this;
     }
 
 }

--- a/StarRailBattleSim/src/powers/PermPower.java
+++ b/StarRailBattleSim/src/powers/PermPower.java
@@ -1,10 +1,13 @@
 package powers;
 
-import relics.RelicStats;
-
 public class PermPower extends AbstractPower {
 
     public PermPower() {
+        this.lastsForever = true;
+    }
+
+    public PermPower(String name) {
+        super(name);
         this.lastsForever = true;
     }
 

--- a/StarRailBattleSim/src/powers/TempPower.java
+++ b/StarRailBattleSim/src/powers/TempPower.java
@@ -1,11 +1,22 @@
 package powers;
 
-import relics.RelicStats;
-
 public class TempPower extends AbstractPower {
 
     public TempPower() {
+        super();
+    }
 
+    public TempPower(String name) {
+        super(name);
+    }
+
+    public TempPower(int turns) {
+        this.turnDuration = turns;
+    }
+
+    public TempPower(int turns, String name) {
+        super(name);
+        this.turnDuration = turns;
     }
 
     /**
@@ -24,5 +35,4 @@ public class TempPower extends AbstractPower {
         power.setStat(stat, value);
         return power;
     }
-
 }

--- a/StarRailBattleSim/src/powers/TracePower.java
+++ b/StarRailBattleSim/src/powers/TracePower.java
@@ -1,0 +1,9 @@
+package powers;
+
+public class TracePower extends PermPower{
+
+    public TracePower() {
+        this.name = "Traces Stat Bonus";
+    }
+
+}

--- a/StarRailBattleSim/src/relics/BrokenKeel.java
+++ b/StarRailBattleSim/src/relics/BrokenKeel.java
@@ -5,6 +5,7 @@ import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -14,10 +15,7 @@ public class BrokenKeel extends AbstractRelicSetBonus {
     }
 
     public void onEquip() {
-        PermPower statBonus = new PermPower();
-        statBonus.name = "Broken Keel Stat Bonus";
-        statBonus.bonusEffectRes = 10;
-        owner.addPower(statBonus);
+        owner.addPower(PermPower.create(PowerStat.EFFECT_RES, 10, "Broken Keel Effect Resistance Bonus"));
     }
 
     public void onCombatStart() {

--- a/StarRailBattleSim/src/relics/InertSalsotto.java
+++ b/StarRailBattleSim/src/relics/InertSalsotto.java
@@ -4,6 +4,7 @@ import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -12,10 +13,7 @@ public class InertSalsotto extends AbstractRelicSetBonus {
         super(owner);
     }
     public void onEquip() {
-        PermPower statBonus = new PermPower();
-        statBonus.name = "Inert Salsotto Stat Bonus";
-        statBonus.bonusCritChance = 8;
-        owner.addPower(statBonus);
+        owner.addPower(PermPower.create(PowerStat.CRIT_CHANCE, 8, "Inert Salsotto Crit Chance Bonus"));
     }
 
     public void onCombatStart() {

--- a/StarRailBattleSim/src/relics/Knight.java
+++ b/StarRailBattleSim/src/relics/Knight.java
@@ -2,6 +2,7 @@ package relics;
 
 import characters.AbstractCharacter;
 import powers.PermPower;
+import powers.PowerStat;
 
 public class Knight extends AbstractRelicSetBonus {
     public Knight(AbstractCharacter owner) {
@@ -12,10 +13,7 @@ public class Knight extends AbstractRelicSetBonus {
     }
 
     public void onEquip() {
-        PermPower statBonus = new PermPower();
-        statBonus.name = "Knight Stat Bonus";
-        statBonus.bonusDefPercent = 15;
-        owner.addPower(statBonus);
+        owner.addPower(PermPower.create(PowerStat.DEF_PERCENT, 15, "Knight Defense Bonus"));
     }
 
     public String toString() {

--- a/StarRailBattleSim/src/relics/Longevous.java
+++ b/StarRailBattleSim/src/relics/Longevous.java
@@ -2,6 +2,7 @@ package relics;
 
 import characters.AbstractCharacter;
 import powers.PermPower;
+import powers.PowerStat;
 
 public class Longevous extends AbstractRelicSetBonus {
     public Longevous(AbstractCharacter owner) {
@@ -12,10 +13,7 @@ public class Longevous extends AbstractRelicSetBonus {
     }
 
     public void onEquip() {
-        PermPower statBonus = new PermPower();
-        statBonus.name = "Longevous Stat Bonus";
-        statBonus.bonusHPPercent = 12;
-        owner.addPower(statBonus);
+        this.owner.addPower(PermPower.create(PowerStat.HP_PERCENT, 12, "Longevous Stat Bonus"));
     }
 
     public String toString() {

--- a/StarRailBattleSim/src/relics/Musketeer.java
+++ b/StarRailBattleSim/src/relics/Musketeer.java
@@ -4,6 +4,7 @@ import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -18,9 +19,9 @@ public class Musketeer extends AbstractRelicSetBonus {
     public void onEquip() {
         PermPower statBonus = new PermPower();
         statBonus.name = "Musketeer Stat Bonus";
-        statBonus.bonusAtkPercent = 12;
+        statBonus.setStat(PowerStat.ATK_PERCENT, 12);;
         if (this.isFullSet) {
-            statBonus.bonusSpeedPercent = 6;
+            statBonus.setStat(PowerStat.SPEED_PERCENT, 6);
         }
         owner.addPower(statBonus);
     }

--- a/StarRailBattleSim/src/relics/RelicStats.java
+++ b/StarRailBattleSim/src/relics/RelicStats.java
@@ -2,6 +2,7 @@ package relics;
 
 import characters.AbstractCharacter;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,21 +26,22 @@ public class RelicStats {
 
     public void equipTo(AbstractCharacter character) {
         PermPower relicBonus = new PermPower();
-        relicBonus.bonusFlatHP = getTotalBonus(Stats.HP_FLAT);
-        relicBonus.bonusFlatAtk = getTotalBonus(Stats.ATK_FLAT);
-        relicBonus.bonusFlatDef = getTotalBonus(Stats.DEF_FLAT);
-        relicBonus.bonusHPPercent = getTotalBonus(Stats.HP_PER);
-        relicBonus.bonusAtkPercent = getTotalBonus(Stats.ATK_PER);
-        relicBonus.bonusDefPercent = getTotalBonus(Stats.DEF_PER);
-        relicBonus.bonusCritChance = getTotalBonus(Stats.CRIT_RATE);
-        relicBonus.bonusCritDamage = getTotalBonus(Stats.CRIT_DAMAGE);
-        relicBonus.bonusEffectHit = getTotalBonus(Stats.EFFECT_HIT);
-        relicBonus.bonusEffectRes = getTotalBonus(Stats.EFFECT_RES);
-        relicBonus.bonusBreakEffect = getTotalBonus(Stats.BREAK_EFFECT);
-        relicBonus.bonusFlatSpeed = getTotalBonus(Stats.SPEED);
-        relicBonus.bonusHealing = getTotalBonus(Stats.HEALING);
-        relicBonus.bonusEnergyRegen = getTotalBonus(Stats.ERR);
-        relicBonus.bonusSameElementDamageBonus = getTotalBonus(Stats.ELEMENT_DAMAGE);
+
+        relicBonus.setStat(PowerStat.FLAT_HP, getTotalBonus(Stats.HP_FLAT));
+        relicBonus.setStat(PowerStat.FLAT_ATK, getTotalBonus(Stats.ATK_FLAT));
+        relicBonus.setStat(PowerStat.FLAT_DEF, getTotalBonus(Stats.DEF_FLAT));
+        relicBonus.setStat(PowerStat.HP_PERCENT, getTotalBonus(Stats.HP_PER));
+        relicBonus.setStat(PowerStat.ATK_PERCENT, getTotalBonus(Stats.ATK_PER));
+        relicBonus.setStat(PowerStat.DEF_PERCENT, getTotalBonus(Stats.DEF_PER));
+        relicBonus.setStat(PowerStat.CRIT_CHANCE, getTotalBonus(Stats.CRIT_RATE));
+        relicBonus.setStat(PowerStat.CRIT_DAMAGE, getTotalBonus(Stats.CRIT_DAMAGE));
+        relicBonus.setStat(PowerStat.EFFECT_HIT, getTotalBonus(Stats.EFFECT_HIT));
+        relicBonus.setStat(PowerStat.EFFECT_RES, getTotalBonus(Stats.EFFECT_RES));
+        relicBonus.setStat(PowerStat.BREAK_EFFECT, getTotalBonus(Stats.BREAK_EFFECT));
+        relicBonus.setStat(PowerStat.FLAT_SPEED, getTotalBonus(Stats.SPEED));
+        relicBonus.setStat(PowerStat.HEALING, getTotalBonus(Stats.HEALING));
+        relicBonus.setStat(PowerStat.ENERGY_REGEN, getTotalBonus(Stats.ERR));
+        relicBonus.setStat(PowerStat.SAME_ELEMENT_DAMAGE_BONUS, getTotalBonus(Stats.ELEMENT_DAMAGE));
         relicBonus.name = "Relic Stats Bonuses";
         character.addPower(relicBonus);
     }

--- a/StarRailBattleSim/src/relics/RutilentArena.java
+++ b/StarRailBattleSim/src/relics/RutilentArena.java
@@ -4,6 +4,7 @@ import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -12,10 +13,7 @@ public class RutilentArena extends AbstractRelicSetBonus {
         super(owner);
     }
     public void onEquip() {
-        PermPower statBonus = new PermPower();
-        statBonus.name = "Rutilent Arena Stat Bonus";
-        statBonus.bonusCritChance = 8;
-        owner.addPower(statBonus);
+        owner.addPower(PermPower.create(PowerStat.CRIT_CHANCE, 8, "Rutilent Arena Crit Chance Bonus"));
     }
 
     public void onCombatStart() {

--- a/StarRailBattleSim/src/relics/Thief.java
+++ b/StarRailBattleSim/src/relics/Thief.java
@@ -2,6 +2,7 @@ package relics;
 
 import characters.AbstractCharacter;
 import powers.PermPower;
+import powers.PowerStat;
 
 public class Thief extends AbstractRelicSetBonus {
     public Thief(AbstractCharacter owner) {
@@ -14,9 +15,9 @@ public class Thief extends AbstractRelicSetBonus {
     public void onEquip() {
         PermPower statBonus = new PermPower();
         statBonus.name = "Thief Stat Bonus";
-        statBonus.bonusBreakEffect = 16;
+        statBonus.setStat(PowerStat.BREAK_EFFECT, 16);
         if (isFullSet) {
-            statBonus.bonusBreakEffect += 16;
+            statBonus.increaseStat(PowerStat.BREAK_EFFECT, 16);
         }
         owner.addPower(statBonus);
     }

--- a/StarRailBattleSim/src/relics/Valorous.java
+++ b/StarRailBattleSim/src/relics/Valorous.java
@@ -4,6 +4,7 @@ import characters.AbstractCharacter;
 import enemies.AbstractEnemy;
 import powers.AbstractPower;
 import powers.PermPower;
+import powers.PowerStat;
 
 import java.util.ArrayList;
 
@@ -18,9 +19,9 @@ public class Valorous extends AbstractRelicSetBonus {
     public void onEquip() {
         PermPower statBonus = new PermPower();
         statBonus.name = "Valorous Stat Bonus";
-        statBonus.bonusAtkPercent = 12;
+        statBonus.setStat(PowerStat.ATK_PERCENT, 12);
         if (this.isFullSet) {
-            statBonus.bonusCritChance = 6;
+            statBonus.setStat(PowerStat.CRIT_CHANCE, 6);
         }
         owner.addPower(statBonus);
     }


### PR DESCRIPTION
Heya, me again :stuck_out_tongue: 

As I indicated with the enum before, I've moved everything over to use the enum. And use a Map to store stats, rather than a public field for everything. 

Checked with the debug, and report that they generate the same numbers, and they do :tada: but, may be worth double-checking. 

There is also a DefaultLightcone to stop NPE when using a character without one. 

Tomorrow relics and then I'll leave you alone :sweat_smile: 